### PR TITLE
CSRF protection for signin/signout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
+OCAML_VERSION ?= 4.12.1
+
 init:
-	git submodule init
-	git submodule update
-	opam switch create . -y --no-install 4.12.1
-	opam install ./hyper -y --deps-only
+	opam switch create . -y --no-install $(OCAML_VERSION)
 	opam install . -y --deps-only
-	opam install -y ppx_expect
 	opam install -y ocaml-lsp-server ocamlformat
 
 build:

--- a/dream-oauth2.opam
+++ b/dream-oauth2.opam
@@ -4,14 +4,14 @@ description: """
 This library allows one to add authentication with external identity provides
 (currently GitHub only) in Dream applications.
 """
-homepage: "https://github.com/andreypopp/dream-oauth2"
+homepage: "https://github.com/camlworks/dream-social-login"
 maintainer: "Andrey Popp <me@andreypopp.com>"
 authors: ["Andrey Popp <me@andreypopp.com>"]
-bug-reports: "https://github.com/andreypopp/dream-oauth2/issues"
+bug-reports: "https://github.com/camlworks/dream-social-login/issues"
 depends: [
   "dream" {>= "1.0.0~alpha4"}
   "dune" {>= "2.9.0"}
-  "hyper"
+  "hyper" {= "1.0.0~alpha1"}
   "lwt_ppx"
   "yojson"
   "odoc" {with-doc}
@@ -31,4 +31,10 @@ build: [
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]
+]
+pin-depends: [
+  ["hyper.1.0.0~alpha1" "git+https://github.com/aantron/hyper.git#7435f26"]
+  ["dream.1.0.0~alpha4" "git+https://github.com/aantron/dream.git#dcc3513"]
+  ["dream-httpaf.1.0.0~alpha4" "git+https://github.com/aantron/dream.git#dcc3513"]
+  ["dream-pure.1.0.0~alpha4" "git+https://github.com/aantron/dream.git#dcc3513"]
 ]

--- a/example/main.eml.ml
+++ b/example/main.eml.ml
@@ -35,7 +35,8 @@ let render request =
     <hr>
 % | Some profile ->
     <p>Signed in as <%s profile.Dream_oauth2.User_profile.user %>.<p>
-    <p><a href="/oauth2/signout">Sign out</a></p>
+%   let signout_form = Dream_oauth2.signout_form request in
+    <p><%s! signout_form %></p>
     <hr>
     <form method="POST" action="/">
       <%s! Dream.csrf_tag request %>

--- a/example/main.eml.ml
+++ b/example/main.eml.ml
@@ -27,8 +27,11 @@ let render request =
 
 % begin match Dream_oauth2.user_profile request with
 % | None ->
+%   let authorize_url =
+%     Dream_oauth2.signin_url ~client_id ~redirect_uri request
+%   in
     <p>Please sign in to chat!</p>
-    <p><a href="/oauth2/signin">Sign in with GitHub</a></p>
+    <p><a href="<%s authorize_url %>">Sign in with GitHub</a></p>
     <hr>
 % | Some profile ->
     <p>Signed in as <%s profile.Dream_oauth2.User_profile.user %>.<p>
@@ -54,7 +57,7 @@ let () =
   @@ Dream.memory_sessions
   @@ Dream.router [
 
-    Dream_oauth2.route ~client_id ~client_secret ~redirect_uri ();
+    Dream_oauth2.route ~client_id ~client_secret ();
 
     Dream.get "/" (fun request ->
       Dream.html (render request));

--- a/src/dream_oauth2.mli
+++ b/src/dream_oauth2.mli
@@ -18,12 +18,23 @@ val signin_url :
     default value is [3600.] which is one hour.
   *)
 
+val signout_form : ?signout_url:string -> Dream.request -> string
+(** Generate an HTML form which performs a logout.
+
+    The form submits a POST request to a CSRF protected [signout_url] (default
+    is "/oauth2/signout").
+
+    Application will usually want to implement its own sign out form with custom
+    design.
+  *)
+
 val route :
   client_id:string ->
   client_secret:string ->
   ?redirect_on_signin:string ->
   ?redirect_on_signout:string ->
-  ?redirect_on_expired_error:string ->
+  ?redirect_on_signin_expired:string ->
+  ?redirect_on_signout_expired:string ->
   unit ->
   Dream.route
 (** Create a set of routes for performing authentication with an identity provider.
@@ -53,3 +64,13 @@ val route :
 val user_profile : Dream.request -> User_profile.t option
 (** [user_profile req] returns [User_profile.t option] information associated
     with the [req] request, if it has any. *)
+
+val signout : Dream.response -> Dream.request -> unit
+(** [signout res req] makes a browser receiving the [res] clear the
+    authenticated [User_profile.t] info.
+
+    This is a low-level API which can be used to perform a custom sign-out flow.
+    Users of this API are responsible for implementing (or not implementing) CSRF
+    protection themselves.
+
+  *)

--- a/src/dream_oauth2.mli
+++ b/src/dream_oauth2.mli
@@ -6,24 +6,36 @@ module User_profile : sig
   (** Information about an authenticated user. *)
 end
 
+val signin_url :
+  ?valid_for:float ->
+  client_id:string ->
+  redirect_uri:string ->
+  Dream.request ->
+  string
+(** Generate an URL which signs user in with an identity provider.
+
+    The optional [valid_for] param specifies (in seconds) the lifetime of the link, the
+    default value is [3600.] which is one hour.
+  *)
+
 val route :
   client_id:string ->
   client_secret:string ->
-  redirect_uri:string ->
   ?redirect_on_signin:string ->
   ?redirect_on_signout:string ->
+  ?redirect_on_expired_error:string ->
   unit ->
   Dream.route
 (** Create a set of routes for performing authentication with an identity provider.
 
     The following endpoints are provided:
 
-    - {b /oauth2/signin} initiates the authentication flow. The user is
-      redirected to the identity provider.
-
     - {b /oauth2/callback} receives the callback request from an identity
       provider, validates it, persists authenticated [User_profile.t] information
-      and finally redirects to [redirect_on_signin] location (by default it is /).
+      and finally redirects to [redirect_on_signin] location (default is ["/"]).
+
+      In case `state` parameter received by the callback is expired then user is
+      redirected on [redirect_on_expired_error] location (default is ["/"]).
 
     - {b /oauth2/signout} drops authentication information and redirects
       to [redirect_on_signout] location (by default it is /).


### PR DESCRIPTION
This addresses #1, #2 and #3.

The PR implements the suggested (in the issues) approach for CSRF protecting signin and signout flows:

- In the signin flow the `state` param is made to be a CSRF token. The signin endpoint is removed and `signin_url` API is added to generate a link to start the signin flow with the provider directly.

- In the signout flow, the endpoint is made to accept only `POST` requests with CSRF token inside. The low-level `signout` API is added to make it possible to implement custom signout flows (see end of the discussion below).

---

### Discussion

The downside of the approach is that a CSRF token has expiration time and thus after some time links to signin and signout flows become invalid.

This is OK UX-wise for apps which have a separate signin page (most of them?) as users will have only one way to interact with the page (either perform signin or leave).

In addition to that, in the case of an expired token we can redirect them back to the signin page and ask to restart the flow.

For the apps which don't have a separate signin page (signin form embedded in the app's chrome) the suggested approach can result in poor UX - tokens expire more often (especially in SPA setting).

We can think of several more approaches here to improve UX and keep CSRF protection:

- We set some large value for the CSRF token's expiration time (possible with `signin_url` API added in this PR).

- We can use a separate SameSite=strict session cookie to control login/logout state transactions as suggested here https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-02#section-8.8.2

- We can check `Origin` header.

Regarding specifically the signout endpoint — some services (notably Google) don't implement logout CSRF protection at all. I think in general it depends on a particular app (some may want to do CSRF protection and some don't).

In this case dream-social-login may suggest the most secure approach by default (`POST` form with CSRF token) and then provide low-level API (see `signout`) to implement a custom flow.
